### PR TITLE
Add monorepo flag to test job in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,5 +5,7 @@ on: push
 jobs:
   test:
     uses: jill64/.github/.github/workflows/run-vitest.yml@main
+    with:
+      monorepo: 'true'
   test-e2e:
     uses: jill64/.github/.github/workflows/run-playwright.yml@main

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,8 +1,8 @@
 {
   "type": "module",
   "scripts": {
-    "build": "wrangler deploy --dry-run",
-    "deploy": "wrangler deploy",
+    "build": "npx wrangler deploy --dry-run",
+    "deploy": "npx wrangler deploy",
     "lint": "npx eslint . && npx depcheck && tsc",
     "format": "npx prettier --write ."
   }


### PR DESCRIPTION
This pull request adds a `monorepo` flag to the `test` job in the `ci.yml` file. This flag allows for testing of monorepo projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow to support monorepo configurations in the test job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->