### PR TITLE
Fix types in GhostPayload and workers.ts

### DIFF
--- a/packages/ghost/actions.ts
+++ b/packages/ghost/actions.ts
@@ -49,7 +49,7 @@ export const actions = (
           owner,
           repo,
           status: 'completed',
-          details_url,
+          details_url
         })
       }
 

--- a/packages/ghost/actions.ts
+++ b/packages/ghost/actions.ts
@@ -44,12 +44,12 @@ export const actions = (
           typeof param === 'string' ? { conclusion: param } : param
 
         await octokit.rest.checks.update({
+          ...outputs,
           check_run_id,
           owner,
           repo,
           status: 'completed',
           details_url,
-          ...outputs
         })
       }
 

--- a/packages/ghost/workers.ts
+++ b/packages/ghost/workers.ts
@@ -17,7 +17,7 @@ export const workers = async (
 
     const createCheckRun = async (name: string) => {
       if (!(head_sha && Number(head_sha) !== 0)) {
-        return 0
+        return ''
       }
 
       const {
@@ -30,7 +30,7 @@ export const workers = async (
         status: 'in_progress'
       })
 
-      return id
+      return id.toString()
     }
 
     const data = await attempt(

--- a/packages/types/GhostPayload.ts
+++ b/packages/types/GhostPayload.ts
@@ -1,3 +1,3 @@
 export type GhostPayload = {
-  check_run_id: number
+  check_run_id: string
 }

--- a/packages/types/WorkerContext.ts
+++ b/packages/types/WorkerContext.ts
@@ -9,5 +9,5 @@ export type WorkerContext = {
   repository: Repository
   payload: Schema
   installation: OctoflareInstallation
-  createCheckRun: (name: string) => Promise<number>
+  createCheckRun: (name: string) => Promise<string>
 }


### PR DESCRIPTION
This pull request fixes the types in GhostPayload and workers.ts files. Specifically, it changes the type of check_run_id from number to string in GhostPayload and in WorkerContext. Additionally, it removes the unnecessary return type of 0 in createCheckRun function in workers.ts.

No issue number reference is needed for this pull request.