### PR TITLE
Fix git commands in syncChanges function

### DIFF
--- a/.github/workflows/wraith-ci.yml
+++ b/.github/workflows/wraith-ci.yml
@@ -46,22 +46,20 @@ jobs:
 
   revoke-installation-token:
     needs: wraith-ci
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Revoke tokens
-        run: |
-          curl -L \
-            -X DELETE \
-            -H "Authorization: Bearer ${{ env.token }}" \
-            https://api.github.com/installation/token
+      - name: Revoke token
+        run: gh api --method DELETE /installation/token
+        env:
+          GH_TOKEN: ${{ env.token }}
 
   revoke-app-token:
     needs: wraith-ci
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Revoke tokens
-        run: |
-          curl -L \
-            -X DELETE \
-            -H "Authorization: Bearer ${{ fromJson(inputs.payload).app_token }}" \
-            https://api.github.com/installation/token
+      - name: Revoke token
+        run: gh api --method DELETE /installation/token
+        env:
+          GH_TOKEN: ${{ fromJson(inputs.payload).app_token }}

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -19,6 +19,11 @@ action(async (context) => {
   const { ghosts, repo, owner } = payload
 
   const ghost = apps[app_name]
+
+  if (!(app_name in ghosts)) {
+    return
+  }
+
   const ghost_payload = ghosts[app_name]
 
   const { check_run_id } = ghost_payload

--- a/packages/action/src/utils/gitDiff.ts
+++ b/packages/action/src/utils/gitDiff.ts
@@ -8,12 +8,5 @@ export const gitDiff = async () => {
     silent: true
   })
 
-  if (diff) {
-    await exec.exec('git config user.name wraith-ci[bot]')
-    await exec.exec(
-      'git config user.email 41898282+wraith-ci[bot]@users.noreply.github.com'
-    )
-  }
-
   return diff
 }

--- a/packages/action/src/utils/gitDiff.ts
+++ b/packages/action/src/utils/gitDiff.ts
@@ -4,7 +4,8 @@ export const gitDiff = async () => {
   await exec.exec('git add -N .')
 
   const diff = await exec.exec('git diff --exit-code', undefined, {
-    ignoreReturnCode: true
+    ignoreReturnCode: true,
+    silent: true
   })
 
   if (diff) {

--- a/packages/action/src/utils/syncChanges.ts
+++ b/packages/action/src/utils/syncChanges.ts
@@ -29,7 +29,7 @@ export const syncChanges = async ({
   await exec('git commit', ['-m', message])
 
   if (require_new_branch) {
-    await exec('git push origin', [head_branch])
+    await exec('git push origin')
 
     await octokit.rest.pulls.create({
       owner,


### PR DESCRIPTION
This pull request fixes the git push command in the syncChanges function and adds the silent option to the gitDiff command to avoid unnecessary output. Additionally, it removes unnecessary code from the revoke-installation-token and revoke-app-token jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Improved GitHub Actions workflows for better token management and error handling.
- **Refactor**
	- Updated utility functions to suppress unnecessary output and streamline code syncing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->