### PR TITLE
Fix ghost payload check in action

### DIFF
--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -18,13 +18,17 @@ action(async (context) => {
 
   const { ghosts, repo, owner } = payload
 
-  const ghost = apps[app_name]
-
   if (!(app_name in ghosts)) {
     return
   }
 
   const ghost_payload = ghosts[app_name]
+
+  if (!ghost_payload) {
+    return
+  }
+
+  const ghost = apps[app_name]
 
   const { check_run_id } = ghost_payload
 


### PR DESCRIPTION
This pull request fixes a bug in the action where the ghost payload check was not properly implemented. The fix ensures that the app_name is properly checked against the ghosts object before proceeding with the rest of the code. This resolves an issue where the action would fail when the ghost_payload was undefined.