### PR TITLE
Add devDependencies for semver and @types/semver

### DIFF
--- a/packages/action/src/apps.ts
+++ b/packages/action/src/apps.ts
@@ -12,4 +12,4 @@ export const apps = {
   format,
   lint,
   release
-} satisfies Record<Exclude<GhostName, 'docs' | 'merge'>, Ghost>
+} satisfies Record<Exclude<GhostName, 'docs' | 'merge' | 'bump'>, Ghost>

--- a/packages/shared/types/GhostName.ts
+++ b/packages/shared/types/GhostName.ts
@@ -6,3 +6,4 @@ export type GhostName =
   | 'format'
   | 'deploy'
   | 'release'
+  | 'bump'

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -5,5 +5,9 @@
     "deploy": "npx wrangler deploy",
     "lint": "eslint . && tsc",
     "format": "prettier --write ."
+  },
+  "devDependencies": {
+    "@types/semver": "7.5.5",
+    "semver": "7.5.4"
   }
 }

--- a/packages/worker/src/apps.ts
+++ b/packages/worker/src/apps.ts
@@ -1,6 +1,7 @@
 import { GhostName } from '@/shared/types/GhostName.js'
 import { Ghost } from '../types/Ghost.js'
 import { build } from './ghosts/build.js'
+import { bump } from './ghosts/bump/index.js'
 import { deploy } from './ghosts/deploy.js'
 import { docs } from './ghosts/docs/index.js'
 import { format } from './ghosts/format.js'
@@ -15,5 +16,6 @@ export const apps = {
   format,
   lint,
   merge,
-  release
+  release,
+  bump
 } satisfies Record<GhostName, Ghost>

--- a/packages/worker/src/ghosts/bump/index.ts
+++ b/packages/worker/src/ghosts/bump/index.ts
@@ -1,0 +1,129 @@
+import { Ghost } from '@/worker/types/Ghost.js'
+import semver from 'semver'
+import { scanner, string } from 'typescanner'
+import { determineSemType } from './lib/determineSemType.js'
+import { formatVersionStr } from './lib/formatVersionStr.js'
+
+const isPackageJson = scanner({
+  version: string
+})
+
+export const bump: Ghost = async ({
+  repo,
+  owner,
+  payload,
+  installation,
+  createCheckRun
+}) => {
+  if (!('pull_request' in payload)) {
+    return
+  }
+
+  const { repository, pull_request, action } = payload
+
+  if (
+    action !== 'opened' &&
+    action !== 'reopened' &&
+    action !== 'synchronize'
+  ) {
+    return
+  }
+
+  const octokit = installation.kit
+
+  await createCheckRun('Ghost Bump')
+
+  if (pull_request.base.ref !== repository.default_branch) {
+    return {
+      conclusion: 'skipped',
+      output: {
+        title: 'This PR is not targeting the default branch',
+        summary:
+          "This PR is not targeting the default branch, so we won't perform any version checks or bumps."
+      }
+    }
+  }
+
+  if (pull_request.title.startsWith('chore')) {
+    return {
+      conclusion: 'skipped',
+      output: {
+        title: 'This PR was deemed a trivial change',
+        summary:
+          "This PR was considered a trivial change, so we won't perform any version checks or bumps."
+      }
+    }
+  }
+
+  const parser = (str: string) => {
+    const json = JSON.parse(str)
+    return isPackageJson(json) ? json : null
+  }
+
+  const [baseJson, headJson] = await Promise.all([
+    installation.getFile('package.json', {
+      ref: pull_request.base.ref,
+      parser
+    }),
+    installation.getFile('package.json', {
+      ref: pull_request.head.ref,
+      parser
+    })
+  ])
+
+  if (!headJson?.data?.version) {
+    return {
+      conclusion: 'skipped',
+      output: {
+        title: 'No Version Control',
+        summary:
+          "This repository is not version controlled, so we won't perform any version checks or bumps."
+      }
+    }
+  }
+
+  const base_version = formatVersionStr(baseJson?.data?.version)
+  const head_version = formatVersionStr(headJson.data.version)
+
+  if (semver.gt(head_version, base_version)) {
+    return 'success'
+  }
+
+  const semType = determineSemType(pull_request.title)
+  const newVersion = semver.inc(base_version, semType)
+
+  const newJsonStr = JSON.stringify(
+    {
+      ...headJson.data,
+      version: newVersion
+    },
+    null,
+    2
+  )
+
+  await octokit.rest.repos.createOrUpdateFileContents({
+    repo,
+    owner,
+    path: 'package.json',
+    message: `chore: bump to ${newVersion}`,
+    content: Buffer.from(newJsonStr).toString('base64'),
+    branch: pull_request.head.ref,
+    sha: headJson.sha
+  })
+
+  return {
+    conclusion: 'failure',
+    output: {
+      title: 'Version Bump Triggered',
+      summary: `
+Version Integrity Check Failed.
+Auto Bump Triggered.
+
+| Ref   | Version                          |
+| ----- | -------------------------------- |
+| Base  | ${base_version}                  |
+| Head  | ${head_version} => ${newVersion} |
+`
+    }
+  }
+}

--- a/packages/worker/src/ghosts/bump/lib/determineSemType.ts
+++ b/packages/worker/src/ghosts/bump/lib/determineSemType.ts
@@ -1,0 +1,20 @@
+export const determineSemType = (title: string) => {
+  const str = title.toLocaleLowerCase()
+  if (str.startsWith('breaking:')) {
+    return 'major'
+  }
+
+  if (title.startsWith('major:')) {
+    return 'major'
+  }
+
+  if (title.startsWith('minor:')) {
+    return 'minor'
+  }
+
+  if (title.startsWith('feat:')) {
+    return 'minor'
+  }
+
+  return 'patch'
+}

--- a/packages/worker/src/ghosts/bump/lib/formatVersionStr.ts
+++ b/packages/worker/src/ghosts/bump/lib/formatVersionStr.ts
@@ -1,0 +1,7 @@
+import semver from 'semver'
+
+export const formatVersionStr = (str: string | undefined | null) => {
+  const trimmed = str?.trim()
+  const ver = trimmed && trimmed !== 'null' ? semver.clean(trimmed) : null
+  return ver ?? '0.0.0'
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,7 +125,14 @@ importers:
         specifier: 4.5.0
         version: 4.5.0(@types/node@20.8.10)
 
-  packages/worker: {}
+  packages/worker:
+    devDependencies:
+      '@types/semver':
+        specifier: ^7.5.5
+        version: 7.5.5
+      semver:
+        specifier: 7.5.4
+        version: 7.5.4
 
 packages:
 
@@ -1188,6 +1195,10 @@ packages:
 
   /@types/semver@7.5.4:
     resolution: {integrity: sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==}
+    dev: true
+
+  /@types/semver@7.5.5:
+    resolution: {integrity: sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==}
     dev: true
 
   /@typescript-eslint/eslint-plugin@6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,7 +128,7 @@ importers:
   packages/worker:
     devDependencies:
       '@types/semver':
-        specifier: ^7.5.5
+        specifier: 7.5.5
         version: 7.5.5
       semver:
         specifier: 7.5.4
@@ -1193,10 +1193,6 @@ packages:
       undici-types: 5.26.5
     dev: true
 
-  /@types/semver@7.5.4:
-    resolution: {integrity: sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==}
-    dev: true
-
   /@types/semver@7.5.5:
     resolution: {integrity: sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==}
     dev: true
@@ -1347,7 +1343,7 @@ packages:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.53.0)
       '@types/json-schema': 7.0.14
-      '@types/semver': 7.5.4
+      '@types/semver': 7.5.5
       '@typescript-eslint/scope-manager': 6.10.0
       '@typescript-eslint/types': 6.10.0
       '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.2.2)
@@ -1366,7 +1362,7 @@ packages:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.53.0)
       '@types/json-schema': 7.0.14
-      '@types/semver': 7.5.4
+      '@types/semver': 7.5.5
       '@typescript-eslint/scope-manager': 6.9.1
       '@typescript-eslint/types': 6.9.1
       '@typescript-eslint/typescript-estree': 6.9.1(typescript@5.2.2)


### PR DESCRIPTION
This pull request adds the necessary devDependencies for semver and @types/semver to the package.json file. It also includes the implementation of a Ghost Bump feature that checks for version integrity and performs an automatic version bump if necessary. This feature is implemented in the worker package and includes the necessary changes to the package.json file, as well as new files for the implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new 'bump' function to handle pull request events and update package.json files based on specific conditions.
- **Refactor**
	- Modified constraints in the 'satisfies' property of the 'apps' object.
- **Chores**
	- Added new utility functions for semantic versioning and formatting version strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->