### PR TITLE
Add Buffer import for Ghost bump

### DIFF
--- a/packages/worker/src/ghosts/bump/index.ts
+++ b/packages/worker/src/ghosts/bump/index.ts
@@ -1,4 +1,5 @@
 import { Ghost } from '@/worker/types/Ghost.js'
+import { Buffer } from 'node:buffer'
 import semver from 'semver'
 import { scanner, string } from 'typescanner'
 import { determineSemType } from './lib/determineSemType.js'


### PR DESCRIPTION
This pull request adds a `Buffer` import for the `Ghost` bump in the `worker/types/Ghost.js` file. This is necessary for proper functionality and compatibility with the latest version of `node.js`.