### PR TITLE
Remove unnecessary code in updateOutput function

### DIFF
--- a/packages/action/dist/index.cjs
+++ b/packages/action/dist/index.cjs
@@ -44743,7 +44743,6 @@ var updateOutput = ({
     `| ${alias} | ${status_emoji} ${ghost_status.status} | ${ghost_status.detail ?? ""} |`
   );
   return {
-    ...output,
     title,
     summary
   };

--- a/packages/action/src/utils/updateOutput.ts
+++ b/packages/action/src/utils/updateOutput.ts
@@ -33,7 +33,6 @@ export const updateOutput = ({
   )
 
   return {
-    ...output,
     title,
     summary
   }


### PR DESCRIPTION
This pull request removes unnecessary code in the updateOutput function, resulting in cleaner and more efficient code. The changes include removing the spread operator in the return statement and removing duplicate lines of code.