### PR TITLE
Refactor GitHub Actions workflow and update details_url

### DIFF
--- a/.github/workflows/wraith-ci.yml
+++ b/.github/workflows/wraith-ci.yml
@@ -57,12 +57,12 @@ jobs:
           X_JP_ACCESS_TOKEN: ${{ secrets.X_JP_ACCESS_TOKEN }}
           X_JP_ACCESS_SECRET: ${{ secrets.X_JP_ACCESS_SECRET }}
 
-  close-check-run:
+  post-process:
     needs: wraith-ci
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Close check run
+      - name: Close Check Run
         run: |
           gh api \
             --method PATCH \
@@ -70,20 +70,10 @@ jobs:
             --field status=completed \
             --field conclusion=${{ needs.wraith-ci.result }}
 
-  revoke-installation-token:
-    needs: close-check-run
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Revoke token
+      - name: Revoke Installation Token
         run: gh api --method DELETE /installation/token
 
-  revoke-app-token:
-    needs: close-check-run
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Revoke token
+      - name: Revoke App Token
         run: gh api --method DELETE /installation/token
         env:
           GH_TOKEN: ${{ fromJson(inputs.payload).app_token }}

--- a/packages/action/dist/index.cjs
+++ b/packages/action/dist/index.cjs
@@ -44795,7 +44795,7 @@ action(async ({ octokit, payload }) => {
     return;
   }
   const { context } = github_exports;
-  const details_url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+  const details_url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/job/${context.job}`;
   await octokit.rest.checks.update({
     owner,
     repo,

--- a/packages/action/src/index.ts
+++ b/packages/action/src/index.ts
@@ -67,7 +67,7 @@ action<WraithPayload>(async ({ octokit, payload }) => {
   }
 
   const { context } = github
-  const details_url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+  const details_url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}/job/${context.job}`
 
   await octokit.rest.checks.update({
     owner,


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflow and updates the details_url to include the job ID. The changes include:

- Renaming the "close-check-run" job to "post-process"

- Updating the names of the "Close Check Run" and "Revoke Installation Token" steps

- Adding a new step to revoke the app token

- Updating the details_url in the "action" function to include the job ID

These changes improve the readability and maintainability of the workflow and ensure that the details_url links to the correct job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed and reorganized steps in the GitHub Actions workflow for improved consistency and clarity.
- **New Features**
	- Enhanced the detail URL to include job-specific information, providing more precise tracking within a GitHub Actions workflow run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->