### PR TITLE
Refactor updateOutput function to fix ghost_status detail formatting

### DIFF
--- a/packages/action/dist/index.cjs
+++ b/packages/action/dist/index.cjs
@@ -44768,9 +44768,10 @@ var updateOutput = ({
     `${status_emoji} ${alias}`
   );
   const name = job_url ? `[${alias}](${job_url})` : alias;
+  const detail = (ghost_status.detail?.replace(/[|]/g, "") ?? "").split("\n")[0];
   const summary = output.summary.replace(
     new RegExp(`\\| ${alias} \\| .* \\| .* \\|`),
-    `| ${name} | ${status_emoji} ${ghost_status.status} | ${ghost_status.detail ?? ""} |`
+    `| ${name} | ${status_emoji} ${ghost_status.status} | ${detail} |`
   );
   return {
     title,

--- a/packages/action/src/utils/updateOutput.test.ts
+++ b/packages/action/src/utils/updateOutput.test.ts
@@ -35,7 +35,7 @@ test('updateOutput - failure', () => {
     ghost_name: 'lint',
     result: {
       status: 'failure',
-      detail: 'Test Detail'
+      detail: 'Test |Detail\n\n'
     },
     job_url: 'https://example.com/lint',
     output: {

--- a/packages/action/src/utils/updateOutput.ts
+++ b/packages/action/src/utils/updateOutput.ts
@@ -29,11 +29,11 @@ export const updateOutput = ({
 
   const name = job_url ? `[${alias}](${job_url})` : alias
 
+  const detail = ghost_status.detail?.replace(/[|\n]/g, '') ?? ''
+
   const summary = output.summary.replace(
     new RegExp(`\\| ${alias} \\| .* \\| .* \\|`),
-    `| ${name} | ${status_emoji} ${ghost_status.status} | ${
-      ghost_status.detail ?? ''
-    } |`
+    `| ${name} | ${status_emoji} ${ghost_status.status} | ${detail} |`
   )
 
   return {

--- a/packages/action/src/utils/updateOutput.ts
+++ b/packages/action/src/utils/updateOutput.ts
@@ -29,7 +29,7 @@ export const updateOutput = ({
 
   const name = job_url ? `[${alias}](${job_url})` : alias
 
-  const detail = ghost_status.detail?.replace(/[|\n]/g, '') ?? ''
+  const detail = (ghost_status.detail?.replace(/[|]/g, '') ?? '').split('\n')[0]
 
   const summary = output.summary.replace(
     new RegExp(`\\| ${alias} \\| .* \\| .* \\|`),


### PR DESCRIPTION
This pull request refactors the `updateOutput` function to properly format the `detail` field of the `ghost_status` object. Previously, the `detail` field was not properly formatted and caused issues with the output summary. This PR fixes that issue by replacing any `|` characters in the `detail` field and splitting the string at the first newline character.

The following commits are included in this pull request:

- escape output

- Refactor updateOutput function to fix ghost_status detail formatting