### PR TITLE
Update Wraith CI name to use slash instead of hyphen for pull requests

### DIFF
--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -119,7 +119,7 @@ export default octoflare<WraithPayload>(async ({ payload, installation }) => {
     checks: installation.kit.rest.checks.create({
       owner,
       repo,
-      name: `Wraith CI${is_pull_request ? ' - PR' : ''}`,
+      name: `Wraith CI${is_pull_request ? ' / PR' : ''}`,
       head_sha,
       status: 'in_progress',
       output: generateOutput()


### PR DESCRIPTION
This pull request updates the name of the Wraith CI check for pull requests to use a slash instead of a hyphen. This change ensures consistency with other naming conventions and improves readability. No functional changes are included in this pull request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the naming convention for checks in Wraith CI during pull request conditions for better organization and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->