### PR TITLE
Remove stackBlitzBadge from syncHeader

### DIFF
--- a/packages/worker/src/ghosts/docs/steps/syncHeader.ts
+++ b/packages/worker/src/ghosts/docs/steps/syncHeader.ts
@@ -85,26 +85,13 @@ export const syncHeader = ({
       ? [versionBadge, licenseBadge, downloadBadge, bundleSizeBadge]
       : []
 
-  const libName = (
-    repoURL?.pathname?.split('/')?.pop() ??
-    packageName ??
-    repository.name
-  )
-    .replaceAll('-', '--')
-    .replaceAll(' ', '_')
-
-  const stackBlitzBadge = stackblitz
-    ? `[![stackblitz](https://img.shields.io/badge/StackBlitz-${libName}-dodgerblue)](${repository.homepage})`
-    : ''
-
   const badges =
     '<!----- BEGIN GHOST DOCS BADGES ----->' +
     [
       ...npmBadges,
       ...workflowBadges,
       // codecovBadge,
-      siteBadge,
-      stackBlitzBadge
+      siteBadge
     ]
       .filter((x) => x)
       .join(' ') +


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the feature for generating a StackBlitz badge from the documentation steps.

- **Documentation**
  - Updated the documentation process to reflect the removal of StackBlitz badge integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->