### PR TITLE
temporary force skip in derive

### DIFF
--- a/packages/action/dist/index.cjs
+++ b/packages/action/dist/index.cjs
@@ -34028,36 +34028,8 @@ var deploy = async () => {
 };
 
 // src/ghosts/derive.ts
-var derive = async ({ octokit, payload }) => {
-  const { owner, repo } = payload;
-  const { data: repository } = await octokit.rest.repos.get({
-    owner,
-    repo
-  });
-  const { data: list } = await octokit.rest.pulls.list({
-    owner,
-    repo,
-    state: "open",
-    base: repository.default_branch
-  });
-  if (!list.length) {
-    return {
-      status: "skipped",
-      detail: "No open PRs targeting the default branch were found."
-    };
-  }
-  const result = list.map(
-    (pull) => octokit.rest.pulls.updateBranch({
-      owner,
-      repo,
-      pull_number: pull.number
-    })
-  );
-  await Promise.allSettled(result);
-  return {
-    status: "success",
-    detail: `Updated ${result.length} PRs.`
-  };
+var derive = async () => {
+  return "skipped";
 };
 
 // src/ghosts/docs/index.ts

--- a/packages/action/src/ghosts/derive.ts
+++ b/packages/action/src/ghosts/derive.ts
@@ -1,7 +1,6 @@
 import { Ghost } from '@/action/types/Ghost.js'
 
 export const derive: Ghost = async () => {
-
   return 'skipped'
 
   // const { owner, repo } = payload

--- a/packages/action/src/ghosts/derive.ts
+++ b/packages/action/src/ghosts/derive.ts
@@ -1,39 +1,42 @@
 import { Ghost } from '@/action/types/Ghost.js'
 
-export const derive: Ghost = async ({ octokit, payload }) => {
-  const { owner, repo } = payload
+export const derive: Ghost = async () => {
 
-  const { data: repository } = await octokit.rest.repos.get({
-    owner,
-    repo
-  })
+  return 'skipped'
 
-  const { data: list } = await octokit.rest.pulls.list({
-    owner,
-    repo,
-    state: 'open',
-    base: repository.default_branch
-  })
+  // const { owner, repo } = payload
 
-  if (!list.length) {
-    return {
-      status: 'skipped',
-      detail: 'No open PRs targeting the default branch were found.'
-    }
-  }
+  // const { data: repository } = await octokit.rest.repos.get({
+  //   owner,
+  //   repo
+  // })
 
-  const result = list.map((pull) =>
-    octokit.rest.pulls.updateBranch({
-      owner,
-      repo,
-      pull_number: pull.number
-    })
-  )
+  // const { data: list } = await octokit.rest.pulls.list({
+  //   owner,
+  //   repo,
+  //   state: 'open',
+  //   base: repository.default_branch
+  // })
 
-  await Promise.allSettled(result)
+  // if (!list.length) {
+  //   return {
+  //     status: 'skipped',
+  //     detail: 'No open PRs targeting the default branch were found.'
+  //   }
+  // }
 
-  return {
-    status: 'success',
-    detail: `Updated ${result.length} PRs.`
-  }
+  // const result = list.map((pull) =>
+  //   octokit.rest.pulls.updateBranch({
+  //     owner,
+  //     repo,
+  //     pull_number: pull.number
+  //   })
+  // )
+
+  // await Promise.allSettled(result)
+
+  // return {
+  //   status: 'success',
+  //   detail: `Updated ${result.length} PRs.`
+  // }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified the `derive` function to return "skipped" instead of interacting with external services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->