### PR TITLE
fix: exclude node_modules from findFile

### DIFF
--- a/packages/action/dist/index.cjs
+++ b/packages/action/dist/index.cjs
@@ -33915,7 +33915,9 @@ var findFile = async (filename) => {
     withFileTypes: true,
     recursive: true
   });
-  const files = all.filter((file) => file.isFile() && file.name === filename).map((file) => file.path);
+  const files = all.filter(
+    (file) => file.isFile() && !file.path.includes("node_modules/") && file.name === filename
+  ).map((file) => file.path);
   return files;
 };
 
@@ -33928,6 +33930,7 @@ var overwriteAllVersion = async (newVersion) => {
       const str = await (0, import_promises3.readFile)(file, "utf-8");
       const json = JSON.parse(str);
       if (!json.version) {
+        console.log("No version found in", file);
         return;
       }
       const newJsonStr = JSON.stringify(

--- a/packages/action/src/ghosts/bump/overwriteAllVersion.ts
+++ b/packages/action/src/ghosts/bump/overwriteAllVersion.ts
@@ -13,6 +13,7 @@ export const overwriteAllVersion = async (newVersion: string) => {
       const json = JSON.parse(str)
 
       if (!json.version) {
+        console.log('No version found in', file)
         return
       }
 

--- a/packages/action/src/utils/findFile.ts
+++ b/packages/action/src/utils/findFile.ts
@@ -7,7 +7,12 @@ export const findFile = async (filename: string): Promise<string[]> => {
   })
 
   const files = all
-    .filter((file) => file.isFile() && file.name === filename)
+    .filter(
+      (file) =>
+        file.isFile() &&
+        !file.path.includes('node_modules/') &&
+        file.name === filename
+    )
     .map((file) => file.path)
 
   return files


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved `overwriteAllVersion` function to log a message when no version is detected.
  - Enhanced `findFile` function to ignore files in the 'node_modules' directory for more accurate search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->