### PR TITLE
Add check for base version in bump ghost

### DIFF
--- a/packages/action/dist/index.cjs
+++ b/packages/action/dist/index.cjs
@@ -34014,6 +34014,12 @@ var bump = async ({ payload, octokit }) => {
   });
   const baseJsonData = baseStr ? JSON.parse(baseStr) : null;
   const baseJson = isPackageJson(baseJsonData) ? baseJsonData : null;
+  if (!baseJson?.version) {
+    return {
+      status: "skipped",
+      detail: "No base version found."
+    };
+  }
   const base_version = formatVersionStr(baseJson?.version);
   const head_version = formatVersionStr(headJson.version);
   const semType = cumulativeUpdate ? "patch" : determineSemType(pull_request.title);

--- a/packages/action/src/ghosts/bump/index.ts
+++ b/packages/action/src/ghosts/bump/index.ts
@@ -91,6 +91,13 @@ export const bump: Ghost = async ({ payload, octokit }) => {
   const baseJsonData = baseStr ? JSON.parse(baseStr) : null
   const baseJson = isPackageJson(baseJsonData) ? baseJsonData : null
 
+  if (!baseJson?.version) {
+    return {
+      status: 'skipped',
+      detail: 'No base version found.'
+    }
+  }
+
   const base_version = formatVersionStr(baseJson?.version)
   const head_version = formatVersionStr(headJson.version)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved version verification to ensure functionality only proceeds when a base version is present, enhancing the reliability of the update process. If no base version is found, the update is now gracefully skipped with a clear message for the user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->