### PR TITLE
Refactor listWorkflowFiles to use path.join and add error handling

### DIFF
--- a/packages/action/dist/index.cjs
+++ b/packages/action/dist/index.cjs
@@ -34358,11 +34358,14 @@ var updateReadmeList = async ({
 var import_promises6 = require("node:fs/promises");
 var import_node_path4 = __toESM(require("node:path"), 1);
 var listWorkflowFiles = async () => {
-  const dirPath = ".github/workflows";
-  const dir = await (0, import_promises6.readdir)(dirPath, {
-    withFileTypes: true,
-    recursive: true
-  });
+  const dirPath = import_node_path4.default.join(process.cwd(), ".github/workflows");
+  const dir = await attempt(
+    () => (0, import_promises6.readdir)(dirPath, {
+      withFileTypes: true,
+      recursive: true
+    }),
+    []
+  );
   const result = dir.filter((dirent) => dirent.isFile()).map(async (file) => {
     const filepath = import_node_path4.default.join(dirPath, file.name);
     const data = await (0, import_promises6.readFile)(filepath, "utf-8");

--- a/packages/action/src/ghosts/docs/utils/listWorkflowFiles.ts
+++ b/packages/action/src/ghosts/docs/utils/listWorkflowFiles.ts
@@ -1,12 +1,18 @@
+import { attempt } from '@jill64/attempt'
 import { readdir, readFile } from 'node:fs/promises'
 import path from 'node:path'
 
 export const listWorkflowFiles = async () => {
-  const dirPath = '.github/workflows'
-  const dir = await readdir(dirPath, {
-    withFileTypes: true,
-    recursive: true
-  })
+  const dirPath = path.join(process.cwd(), '.github/workflows')
+
+  const dir = await attempt(
+    () =>
+      readdir(dirPath, {
+        withFileTypes: true,
+        recursive: true
+      }),
+    []
+  )
 
   const result = dir
     .filter((dirent) => dirent.isFile())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error handling in file listing operations with enhanced control flow.

- **Documentation**
	- Updated the function declarations in public API documentation to reflect new error handling strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->