### PR TITLE
Add check for published packages before returning status skipped

### DIFF
--- a/packages/action/src/ghosts/release/index.ts
+++ b/packages/action/src/ghosts/release/index.ts
@@ -26,7 +26,14 @@ export const release: Ghost = async ({ payload: { owner, repo }, octokit }) => {
     }
   }
 
-  await Promise.allSettled(files.map(npmPublish))
+  const result = await Promise.allSettled(files.map(npmPublish))
+
+  if (!result.some((r) => r.status === 'fulfilled' && r.value)) {
+    return {
+      status: 'skipped',
+      detail: 'No package published'
+    }
+  }
 
   const json = await getPackageJson()
   const rootPackageJson = isValidPackageJson(json) ? json : null

--- a/packages/action/src/ghosts/release/npmPublish.ts
+++ b/packages/action/src/ghosts/release/npmPublish.ts
@@ -40,6 +40,6 @@ export const npmPublish = async (file: string) => {
   await exec.exec('npm publish', undefined, {
     cwd
   })
-  
+
   return true
 }

--- a/packages/action/src/ghosts/release/npmPublish.ts
+++ b/packages/action/src/ghosts/release/npmPublish.ts
@@ -18,7 +18,7 @@ export const npmPublish = async (file: string) => {
 
   if (!isValidJson(package_json)) {
     core.info(`[${file}]: No version found.`)
-    return
+    return false
   }
 
   const version = package_json.version.trim()
@@ -34,10 +34,12 @@ export const npmPublish = async (file: string) => {
 
   if (version === publishedVersion.stdout.trim()) {
     core.info(`[${file}]: No update found.`)
-    return
+    return false
   }
 
   await exec.exec('npm publish', undefined, {
     cwd
   })
+  
+  return true
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the release process to provide more detailed feedback when no packages are published.
  
- **Bug Fixes**
  - Ensured the `npmPublish` function accurately reflects the success of the publish operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->