### PR TITLE
fix: lint

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,7 +4,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "npm run build && vite preview",
-    "check": "svelte-kit sync && svelte-check",
+    "check": "svelte-kit sync && npx svelte-check",
     "lint": "npm run check && eslint .",
     "format": "npx psvx"
   }

--- a/packages/api/src/routes/v1/github-webhook/isOwnerTransfered.ts
+++ b/packages/api/src/routes/v1/github-webhook/isOwnerTransfered.ts
@@ -1,5 +1,5 @@
 import { Buffer } from 'node:buffer'
-import type { Octokit } from 'octokit'
+import type { Octokit } from 'octoflare/octokit'
 import { scanner, string } from 'typescanner'
 
 const isValid = scanner({

--- a/packages/api/src/routes/v1/github-webhook/onPR.ts
+++ b/packages/api/src/routes/v1/github-webhook/onPR.ts
@@ -1,6 +1,6 @@
 import type { TriggerEvent } from '$shared/ghost/types/TriggerEvent.js'
 import type { WraithPayload } from '$shared/ghost/types/WraithPayload'
-import type { PullRequestEvent } from '@octokit/webhooks-types'
+import type { PullRequestEvent } from 'octoflare/webhook'
 import type { OctoflareInstallation } from 'octoflare'
 
 export const onPR = async (
@@ -34,7 +34,7 @@ export const onPR = async (
 
   const task = async () => {
     try {
-      const { data } = await installation.rest.issues.listComments({
+      const { data } = await installation.kit.rest.issues.listComments({
         owner,
         repo,
         issue_number: pull_request.number
@@ -47,7 +47,7 @@ export const onPR = async (
             body?.includes('] Wraith CI / PR')
         )
       ) {
-        await installation.rest.issues.createComment({
+        await installation.kit.rest.issues.createComment({
           owner,
           repo,
           issue_number: pull_request.number,

--- a/packages/api/src/routes/v1/github-webhook/onPRCommentEdited.ts
+++ b/packages/api/src/routes/v1/github-webhook/onPRCommentEdited.ts
@@ -1,7 +1,7 @@
 import type { TriggerEvent } from '$shared/ghost/types/TriggerEvent.js'
 import type { WraithPayload } from '$shared/ghost/types/WraithPayload'
 import { attempt } from '@jill64/attempt'
-import type { IssueCommentEditedEvent } from '@octokit/webhooks-types'
+import type { IssueCommentEditedEvent } from 'octoflare/webhook'
 import { text } from '@sveltejs/kit'
 import type { OctoflareInstallation } from 'octoflare'
 
@@ -42,7 +42,7 @@ export const onPRCommentEdited = async (
   }
 
   const commented_pr = await attempt(async () => {
-    const { data } = await installation.rest.pulls.get({
+    const { data } = await installation.kit.rest.pulls.get({
       pull_number: issue.number,
       owner,
       repo
@@ -64,13 +64,13 @@ export const onPRCommentEdited = async (
   const task = async () => {
     try {
       await Promise.allSettled([
-        installation.rest.issues.updateComment({
+        installation.kit.rest.issues.updateComment({
           owner,
           repo,
           comment_id: comment.id,
           body: before
         }),
-        installation.rest.reactions.createForIssueComment({
+        installation.kit.rest.reactions.createForIssueComment({
           owner,
           repo,
           comment_id: comment.id,

--- a/packages/api/src/routes/v1/github-webhook/onPush.ts
+++ b/packages/api/src/routes/v1/github-webhook/onPush.ts
@@ -1,5 +1,5 @@
 import type { TriggerEvent } from '$shared/ghost/types/TriggerEvent.js'
-import type { PushEvent } from '@octokit/webhooks-types'
+import type { PushEvent } from 'octoflare/webhook'
 
 export const onPush = (payload: PushEvent) => {
   const { repository, after: head_sha } = payload

--- a/packages/shared/ghost/types/WraithPayload.ts
+++ b/packages/shared/ghost/types/WraithPayload.ts
@@ -1,4 +1,4 @@
-import { GhostName } from './GhostName.js'
+import type { GhostName } from './GhostName.js'
 
 export type WraithPayload = {
   triggered_ghosts: GhostName[]

--- a/packages/shared/ghost/types/WraithStatus.ts
+++ b/packages/shared/ghost/types/WraithStatus.ts
@@ -1,4 +1,4 @@
-import { GhostName } from './GhostName.js'
-import { GhostStatus } from './GhostStatus.js'
+import type { GhostName } from './GhostName.js'
+import type { GhostStatus } from './GhostStatus.js'
 
 export type WraithStatus = Partial<Record<GhostName, GhostStatus>>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package scripts to use `npx` for `svelte-check`
	- Modified import statements across multiple files to use type-only imports
	- Transitioned webhook-related imports from `@octokit/webhooks-types` to `octoflare/webhook`
	- Updated method calls to use `installation.kit.rest` instead of `installation.rest`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->